### PR TITLE
Remove hamcrest-integration from sdk.tests feature

### DIFF
--- a/features/org.eclipse.sdk.tests/feature.xml
+++ b/features/org.eclipse.sdk.tests/feature.xml
@@ -492,13 +492,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.hamcrest.integration"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.hamcrest.library"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Nothing needs it.

Related to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/179