### PR TITLE
Do not include hamcrest.library in test features.

### DIFF
--- a/features/org.eclipse.sdk.tests/feature.xml
+++ b/features/org.eclipse.sdk.tests/feature.xml
@@ -491,13 +491,6 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.hamcrest.library"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
     <plugin
          id="org.mockito.mockito-core"
          download-size="0"

--- a/features/org.eclipse.test-feature/feature.xml
+++ b/features/org.eclipse.test-feature/feature.xml
@@ -102,13 +102,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.hamcrest.library"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.junit.jupiter.api"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Nothing uses it anymore. This jar no longer even exists in latest
hamcrest versions.