### PR TITLE
[RelEng] Add reusable verifyFreezePeriode workflow

### DIFF
--- a/.github/workflows/callFreezePeriodCheck.yml
+++ b/.github/workflows/callFreezePeriodCheck.yml
@@ -1,0 +1,12 @@
+# This workflow calls the Code-Freeze-Period check
+
+name: Check for Code Freeze Period
+
+on:
+  pull_request:
+    branches: 
+     - 'master'
+
+jobs:
+  check-freeze-period:
+    uses: ./.github/workflows/verifyFreezePeriod.yml

--- a/.github/workflows/verifyFreezePeriod.yml
+++ b/.github/workflows/verifyFreezePeriod.yml
@@ -1,0 +1,23 @@
+# This workflow will check if the project is currently in a Code-Freeze-Period
+
+name: Verify Code Freeze Period
+
+on:
+  workflow_call
+  
+jobs:
+  verify-freeze-period:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking whether Eclipse project is currently in stabilitzation/code-freeze period ...
+        run: |
+          today=$(TZ=UTC date "+%Y%m%d")
+          tomorrow=$(TZ=UTC date -d "+1 days" "+%Y%m%d")
+          calID="cHJmazI2ZmRtcHJ1MW1wdGxiMDZwMGpoNHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
+          curl "https://calendar.google.com/calendar/u/0/htmlembed?src=${calID}&mode=AGENDA&ctz=UTC&dates=${today}/${tomorrow}" | grep -i -q -e "stabilization"
+          if [[ $? == 0 ]]; then
+            echo "::error::Today is a freeze day"
+            exit 1 #Exiting with non-0 makes this workflow fail
+          fi
+          echo "No code freeze today"
+        shell: bash {0} # do not fail-fast

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,14 +32,5 @@ pipeline {
 				}
 			}
 		}
-		stage('Check freeze period') {
-			steps {
-				sh "wget https://download.eclipse.org/eclipse/relengScripts/scripts/verifyFreezePeriod.sh"
-				sh "chmod +x verifyFreezePeriod.sh"
-				withCredentials([string(credentialsId: 'google-api-key', variable: 'GOOGLE_API_KEY')]) {
-					sh './verifyFreezePeriod.sh'
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
This PR moves the Freeze-Period verification from the Jenkins build to a dedicated reusable workflow to get more detailed/clear PR checks as I have suggested on the [Mailing-Lists](https://www.eclipse.org/lists/platform-releng-dev/msg38299.html).

All repositories that require the code-freeze check can add the following file named `.github/workflows/verifyFreezePeriod.yml`:
```
# This workflow calls the Code-Freeze-Period check

name: Check Code Freeze Period

on:
  pull_request:
    branches: 
     - 'master'

jobs:
  check-freeze-period:
    uses: eclipse-platform/eclipse.platform.releng/.github/workflows/verifyFreezePeriod.yml@master
```
And can remove remove the `Check freeze period` stage from their Jenkins file.

The only problem at the moment is, although the calendar is publicly readable, querying the Google Calendar-API requires an authentication for example via the Google-API-Key that is used with the current `verifyFreezePeriod.sh` script: 
https://developers.google.com/calendar/api/guides/auth
https://developers.google.com/calendar/api/v3/reference/events/list

So we either have to store Foundations Google-API-Key in the GitHub organization's secret store or have to avoid using the calendar-API.
I have never worked before with the Google-Calendar API and calenders in general and know almost nothing about it.
But this StackOverflow answer suggest to fetch the data through ical/xml/html:
https://stackoverflow.com/a/18303697

However the following link returns a `basic.ics` file with over 20.000 lines and events going back to 2007:
https://calendar.google.com/calendar/ical/prfk26fdmpru1mptlb06p0jh4s%40group.calendar.google.com/public/basic.ics

Maybe this can searched with a more sophisticated RegEx, but I think there might be better solutions.

Can anybody, who is more proficient in this area, help in this regard.
