### PR TITLE
Remove transitively included o.e.osgi.util from o.e.platform feature

### DIFF
--- a/features/org.eclipse.platform-feature/feature.xml
+++ b/features/org.eclipse.platform-feature/feature.xml
@@ -131,13 +131,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.osgi.util"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.debug.core"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The plug-in `org.eclipse.osgi.util` is already included in `org.eclipse.e4.rcp` and therefore transitively in the `org.eclipse.platform` feature via `org.eclipse.rcp`.

Tycho/P2 considers transitive inclusion already for a long time and with the latest changes in 4.23 and 4.24 PDE supports it as well when launching applications/products and I think even with older versions product launches should work as well because PDE 'manually' included transitively included plugin to the launch. So this can be removed to reduce the maintenance effort (e.g. as a consequence of https://github.com/eclipse-equinox/equinox.framework/pull/41).

@merks Do you agree that this is okay?