### PR TITLE
Adjust fileupload symbolic name to upstream one

### DIFF
--- a/features/org.eclipse.sdk.tests/feature.xml
+++ b/features/org.eclipse.sdk.tests/feature.xml
@@ -422,7 +422,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.apache.commons.fileupload"
+         id="org.apache.commons.commons-fileupload"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Needed due to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/250