### PR TITLE
WIP: POM and product version change for 4.25 release

### DIFF
--- a/bundles/org.eclipse.ant.optional.junit/pom.xml
+++ b/bundles/org.eclipse.ant.optional.junit/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ant</groupId>

--- a/bundles/org.eclipse.rcp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.rcp; singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.rcp/pom.xml
+++ b/bundles/org.eclipse.rcp/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.rcp</groupId>

--- a/bundles/org.eclipse.releng.tests/pom.xml
+++ b/bundles/org.eclipse.releng.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.releng</groupId>

--- a/bundles/org.eclipse.sdk.examples/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sdk.examples/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.sdk.examples; singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.sdk.examples/pom.xml
+++ b/bundles/org.eclipse.sdk.examples/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk</groupId>

--- a/bundles/org.eclipse.sdk.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sdk.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.eclipse.sdk.tests; singleton:=true
-Bundle-Version: 4.24.0.qualifier
+Bundle-Version: 4.25.0.qualifier
 Eclipse-BundleShape: dir
 

--- a/bundles/org.eclipse.sdk.tests/pom.xml
+++ b/bundles/org.eclipse.sdk.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk</groupId>

--- a/bundles/org.eclipse.test.performance.win32/pom.xml
+++ b/bundles/org.eclipse.test.performance.win32/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test</groupId>

--- a/bundles/org.eclipse.test.performance/pom.xml
+++ b/bundles/org.eclipse.test.performance/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test</groupId>

--- a/bundles/org.eclipse.test/pom.xml
+++ b/bundles/org.eclipse.test/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test</groupId>

--- a/features/org.eclipse.help-feature/pom.xml
+++ b/features/org.eclipse.help-feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.help.feature</groupId>

--- a/features/org.eclipse.platform-feature/feature.xml
+++ b/features/org.eclipse.platform-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.platform"
       label="%featureName"
-      version="4.24.0.qualifier"
+      version="4.25.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.platform-feature/pom.xml
+++ b/features/org.eclipse.platform-feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.platform.feature</groupId>

--- a/features/org.eclipse.platform-feature/rootfiles/.eclipseproduct
+++ b/features/org.eclipse.platform-feature/rootfiles/.eclipseproduct
@@ -1,3 +1,3 @@
 name=Eclipse Platform
 id=org.eclipse.platform
-version=4.24.0
+version=4.25.0

--- a/features/org.eclipse.rcp/feature.xml
+++ b/features/org.eclipse.rcp/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.rcp"
       label="%featureName"
-      version="4.24.0.qualifier"
+      version="4.25.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.rcp"
       license-feature="org.eclipse.license"

--- a/features/org.eclipse.rcp/pom.xml
+++ b/features/org.eclipse.rcp/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.rcp.feature</groupId>

--- a/features/org.eclipse.sdk.examples-feature/feature.xml
+++ b/features/org.eclipse.sdk.examples-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk.examples"
       label="%featureName"
-      version="4.24.0.qualifier"
+      version="4.25.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.sdk.examples-feature/pom.xml
+++ b/features/org.eclipse.sdk.examples-feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk.feature</groupId>

--- a/features/org.eclipse.sdk.tests/feature.xml
+++ b/features/org.eclipse.sdk.tests/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk.tests"
       label="%featureName"
-      version="4.24.0.qualifier"
+      version="4.25.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.sdk.tests/forceQualifierUpdate.txt
+++ b/features/org.eclipse.sdk.tests/forceQualifierUpdate.txt
@@ -10,4 +10,4 @@ Bug 468331 - Update EGit/JGit compile-time dependencies to Mars level
 Bug 480835 - Failures in build due to changes not being picked up by tests
 Bug 566156 - 4.17 I-Build: I20200818-0600 - BUILD FAILED
 4.20 I-Build: I20210518-0600 - BUILD FAILED
-Bug 577522 - Update test framework dependencies
+Bug 577522 - Update test framework dependencies 

--- a/features/org.eclipse.sdk.tests/pom.xml
+++ b/features/org.eclipse.sdk.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk.feature</groupId>

--- a/features/org.eclipse.sdk/feature.xml
+++ b/features/org.eclipse.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sdk"
       label="%featureName"
-      version="4.24.0.qualifier"
+      version="4.25.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.sdk/pom.xml
+++ b/features/org.eclipse.sdk/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.sdk.feature</groupId>

--- a/features/org.eclipse.test-feature/pom.xml
+++ b/features/org.eclipse.test-feature/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>eclipse.platform.releng</groupId>
     <artifactId>eclipse.platform.releng</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.test.feature</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290)

Can't be merged until after 4.24 release