### PR TITLE
Adding source bundles needed for 4.24 release

### DIFF
--- a/publish-to-maven-central/sourceBundles.txt
+++ b/publish-to-maven-central/sourceBundles.txt
@@ -2,4 +2,88 @@ eclipse-platform/eclipse.platform.ui.tools.git \
 	bundles/org.eclipse.e4.tools.emf.ui \
 	S4_24_0_RC2a \
 	org/eclipse/platform org.eclipse.e4.tools.emf.ui 4.7.300
-	
+
+eclipse-platform/eclipse.platform.swt.git \
+	bundles/org.eclipse.swt \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.swt 3.120.0
+
+ eclipse-platform/eclipse.platform.releng.git \
+	bundles/org.eclipse.rcp \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.rcp 4.24.0
+
+eclipse-platform/eclipse.platform.common.git \
+	bundles/org.eclipse.platform.doc.isv \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.platform.doc.isv 4.24.0
+
+eclipse-platform/eclipse.platform.common.git \
+	bundles/org.eclipse.platform.doc.user \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.platform.doc.user 4.24.0
+
+eclipse-platform/eclipse.platform.common.git \
+	bundles/org.eclipse.jdt.doc.user \
+	S4_24_0_RC2a \
+	org/eclipse/jdt org.eclipse.jdt.doc.user 3.15.1400
+
+eclipse-platform/eclipse.platform.common.git \
+	bundles/org.eclipse.jdt.doc.isv \
+	S4_24_0_RC2a \
+	org/eclipse/jdt org.eclipse.jdt.doc.isv 3.14.1600
+
+eclipse-platform/eclipse.platform.common.git \
+	bundles/org.eclipse.pde.doc.user \
+	S4_24_0_RC2a \
+	org/eclipse/pde org.eclipse.pde.doc.user 3.14.1600
+
+eclipse-jdt/eclipse.jdt.git \
+	org.eclipse.jdt \
+	S4_24_0_RC2a \
+	org/eclipse/jdt org.eclipse.jdt 3.18.1200
+
+eclipse-pde/eclipse.pde.git \
+	ui/org.eclipse.pde \
+	S4_24_0_RC2a \
+	org/eclipse/pde org.eclipse.pde 3.13.1900
+
+eclipse-platform/eclipse.platform.releng.git \
+	features/org.eclipse.sdk \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.sdk 4.24.0
+
+ eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64 \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.cocoa.macosx.aarch64 1.2.500
+
+eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64 \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.cocoa.macosx.x86_64 1.2.500
+
+eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.cocoa.macosx \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.cocoa.macosx 1.2.500
+
+eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.gtk.linux.ppc64le 1.2.500
+
+eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64 \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.gtk.linux.x86_64 1.2.500
+
+eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64 \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.gtk.linux.aarch64 1.2.500
+
+eclipse-equinox/equinox.framework.git \
+	bundles/org.eclipse.equinox.launcher.win32.win32.x86_64 \
+	S4_24_0_RC2a \
+	org/eclipse/platform org.eclipse.equinox.launcher.win32.win32.x86_64 1.2.500


### PR DESCRIPTION
Tracked in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/327
