### PR TITLE
Adapt SDK4Mvn to addition of org.apache.felix.scr dependencies

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -49,7 +49,7 @@
   <mavenMappings namePattern="(org\.apache\.httpcomponents)\.([^.]+)$" groupId="$1" artifactId="$2"/>
   <mavenMappings namePattern="org\.apache\.lucene\.core" groupId="org.apache.lucene" artifactId="lucene-core"/>
   <mavenMappings namePattern="org\.apache\.lucene\.analysis" groupId="org.apache.lucene" artifactId="lucene-analyzers"/>
-  <mavenMappings namePattern="(org\.apache\.felix)(\.gogo\.[^.]+)" groupId="$1" artifactId="$1$2"/>
+  <mavenMappings namePattern="(org\.apache\.felix)(\..+)" groupId="$1" artifactId="$1$2"/>
   <mavenMappings namePattern="org\.apache\.ant$" groupId="org.apache.ant" artifactId="ant"/>
   <mavenMappings namePattern="(org.apache)\.(sshd)\.(core)" groupId="$1.$2" artifactId="$2-$3"/>
   <mavenMappings namePattern="(org\.objectweb)\.([^.]+)$" groupId="org.ow2.asm" artifactId="$2"/>


### PR DESCRIPTION
With PR https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/282 `org.apache.felix.scr` was added to the Platform-SDK Target:
https://mvnrepository.com/artifact/org.apache.felix/org.apache.felix.scr/2.2.2

Although felix.scr should not be referenced explicitly by a Plug-in, I suggest to adjust the Maven-Mappings to support is as well. Just in case.