### PR TITLE
Update test framework dependencies

### DIFF
--- a/features/org.eclipse.test-feature/forceQualifierUpdate.txt
+++ b/features/org.eclipse.test-feature/forceQualifierUpdate.txt
@@ -12,3 +12,4 @@ Bug 561740 - Update prereqs for 4.16 M1 release: Orbit (mockito rebuild)
 Bug 574602 - Eclipse 4.21 prerequisites: Orbit
 Update test framework dependencies #87 
 Update mockito to 4.5.0
+Updae test framework dependencies 


### PR DESCRIPTION
Touch the feature to pick the new versions. Needed by
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/357