### PR TITLE
SDK4Mvn: Remove default patterns

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -31,9 +31,12 @@
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="aarch64"/>
   <configurations architecture="x86_64"/>
   <mavenMappings namePattern="(org\.eclipse\.jdt)\.core\.compiler\.batch" groupId="$1" artifactId="ecj"/>
+  <!-- TODO, as aggregator smartens up by reading Maven coordinates from jar or p2 metadata, and
+       as Platform adopts direct Maven dependencies in place of Orbit wrappers, and as Platform
+       refines the groupId directly in its own pom; then this list should eventually vanish as
+       default values/behavior would be good enough -->
   <mavenMappings namePattern="(org\.eclipse\.jdt)(.*)" groupId="$1" artifactId="$1$2"/>
   <mavenMappings namePattern="(org\.eclipse\.pde)(.*)" groupId="$1" artifactId="$1$2"/>
-  <mavenMappings namePattern="(org.eclipse.jetty)(.*)" groupId="$1" artifactId="$1$2"/>
   <mavenMappings namePattern="(org.eclipse.ecf)(.*)" groupId="$1" artifactId="$1$2"/>
   <mavenMappings namePattern="(org.eclipse.emf)(.*)" groupId="$1" artifactId="$1$2"/>
   <mavenMappings namePattern="(org\.eclipse)(.*)$" groupId="$1.platform" artifactId="$1$2"/>
@@ -61,13 +64,13 @@
   <mavenMappings namePattern="(org)\.(opentest4j)" groupId="$1.$2" artifactId="$2"/>
   <mavenMappings namePattern="(org)\.(apiguardian)" groupId="$1.$2" artifactId="$2-api"/>
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="org\.(sat4j)\.(.*)" groupId="org.ow2.$1" artifactId="org.ow2.$1.$2"/>
   <mavenMappings namePattern="org.w3c.css.sac" groupId="org.eclipse.birt.runtime" artifactId="org.w3c.css.sac"/>
   <mavenMappings namePattern="org.apache.batik.css" groupId="org.apache.xmlgraphics" artifactId="batik-css" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="com.google.gson" groupId="com.google.code.gson" artifactId="gson"/>
   <mavenMappings namePattern="com.sun.jna.platform" groupId="net.java.dev.jna" artifactId="jna-platform"/>
   <mavenMappings namePattern="com.sun.jna" groupId="net.java.dev.jna" artifactId="jna"/>
-  <mavenMappings namePattern="(org.osgi)(.*)" groupId="$1" artifactId="$1$2"/>
-  <mavenMappings namePattern="^(([^.]+(?:\.[^.]+(?:\.[^.]+)?)?)(?:\.[^.]+)*)$" groupId="$2" artifactId="$1"/>
-  <mavenMappings namePattern="(.*)" groupId="p2.osgi.bundle" artifactId="$1"/>
+  <mavenMappings namePattern="org.apache.jasper.glassfish" groupId="org.apache.jasper" artifactId="glassfish"/>
+  <mavenMappings namePattern="org.w3c.dom.events" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.events"/>
+  <mavenMappings namePattern="org.w3c.dom.smil" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.smil"/>
+  <mavenMappings namePattern="org.w3c.dom.svg" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.svg"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
Default patten mappings have high probability of being incorrect for a random dependency, even more if the artifact initially comes from Maven. So instead of adding some rule that covers that case wrongly, we add nothing an may have the build explicitly failing and requesting a dedicated rule if none of existing ones matches. The failure becomes a hint that this file requires some manual update as a reaction of a dependency change.