### PR TITLE
Import-Package and other requirements not translated as Maven

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -20,9 +20,9 @@
       </repositories>
     </contributions>
     <validationRepositories enabled="false" location="/home/data/httpd/download.eclipse.org/modeling/emf/emf/builds/release/2.30/"/>
-    <validationRepositories location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.30/"/>
+    <validationRepositories enabled="false" location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.30/"/>
     <validationRepositories enabled="false" location="/home/data/httpd/download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
-    <validationRepositories location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
+    <validationRepositories enabled="false" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="ppc64le"/>
@@ -30,44 +30,30 @@
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="aarch64"/>
   <configurations architecture="x86_64"/>
-  <!-- TODO, as aggregator smartens up by reading Maven coordinates from jar or p2 metadata, and
-       as Platform adopts direct Maven dependencies in place of Orbit wrappers, and as Platform
-       refines the groupId directly in its own pom; then this list should eventually vanish as
-       default values/behavior would be good enough -->
   <mavenMappings namePattern="(org\.eclipse\.jdt)\.core\.compiler\.batch" groupId="$1" artifactId="ecj" snapshot="false"/>
   <mavenMappings namePattern="(org\.eclipse\.jdt)(.*)" groupId="$1" artifactId="$1$2" snapshot="false"/>
   <mavenMappings namePattern="(org\.eclipse\.pde)(.*)" groupId="$1" artifactId="$1$2" snapshot="false"/>
-  <mavenMappings namePattern="(org.eclipse.jetty)(.*)" groupId="$1" artifactId="$1$2"/>
-  <mavenMappings namePattern="(org.eclipse.ecf)(.*)" groupId="$1" artifactId="$1$2"/>
-  <mavenMappings namePattern="(org.eclipse.emf)(.*)" groupId="$1" artifactId="$1$2"/>
-  <mavenMappings namePattern="(org\.eclipse)(.*)$" groupId="$1.platform" artifactId="$1$2" snapshot="false"/>
+  <mavenMappings namePattern="(org\.eclipse)((?!(\.emf|\.jetty|\.ecf)).*)$" groupId="$1.platform" artifactId="$1$2" snapshot="false"/>
   <mavenMappings namePattern="(com\.jcraft)\.(.*)" groupId="$1" artifactId="$2"/>
   <mavenMappings namePattern="javax\.annotation" groupId="jakarta.annotation" artifactId="jakarta.annotation-api"/>
-  <mavenMappings namePattern="javax\.el" groupId="javax.el" artifactId="el-api"/>
-  <mavenMappings namePattern="javax\.servlet$" groupId="javax.servlet" artifactId="javax.servlet-api"/>
-  <mavenMappings namePattern="javax\.servlet\.jsp" groupId="javax.servlet.jsp" artifactId="javax.servlet.jsp-api"/>
   <mavenMappings namePattern="(javax.inject)" groupId="$1" artifactId="$1" versionPattern="([^.]+)\.0(?:\..*)?" versionTemplate="$1"/>
-  <mavenMappings namePattern="org\.apache\.(commons)\.([^.]+)" groupId="$1-$2" artifactId="$1-$2" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="(org\.apache\.httpcomponents)\.([^.]+)$" groupId="$1" artifactId="$2"/>
+  <mavenMappings namePattern="org\.apache\.(commons)\.([^.-]+)" groupId="$1-$2" artifactId="$1-$2" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org\.apache\.lucene\.core" groupId="org.apache.lucene" artifactId="lucene-core"/>
-  <mavenMappings namePattern="org\.apache\.lucene\.analysis" groupId="org.apache.lucene" artifactId="lucene-analyzers"/>
+  <mavenMappings namePattern="org.apache.lucene.analyzers-common" groupId="org.apache.lucene" artifactId="lucene-analyzers-common"/>
+  <mavenMappings namePattern="org.apache.lucene.analyzers-smartcn" groupId="org.apache.lucene" artifactId="lucene-analyzers-smartcn"/>
+  <mavenMappings namePattern="(org\.apache\.felix)(\..+)" groupId="$1" artifactId="$1$2"/>
   <mavenMappings namePattern="org\.apache\.ant$" groupId="org.apache.ant" artifactId="ant"/>
-  <mavenMappings namePattern="(org.apache)\.(sshd)\.(core)" groupId="$1.$2" artifactId="$2-$3"/>
-  <mavenMappings namePattern="(org\.objectweb)\.([^.]+)$" groupId="org.ow2.asm" artifactId="$2"/>
-  <mavenMappings namePattern="(org\.objectweb)\.([^.]+)\.([^.]+)" groupId="org.ow2.asm" artifactId="$2-$3"/>
-  <mavenMappings namePattern="org.tukaani.xz" groupId="org.tukaani" artifactId="xz" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="org.hamcrest.core" groupId="org.hamcrest" artifactId="hamcrest-core"/>
-  <mavenMappings namePattern="(org\.junit)\.([^.]+)\.([^.]+)" groupId="$1.$2" artifactId="junit-$2-$3"/>
-  <mavenMappings namePattern="(org\.junit)\.([^.]+)\.([^.]+)\.([^.]+)" groupId="$1.$2" artifactId="junit-$2-$3-$4"/>
+  <mavenMappings namePattern="(org.apache)\.(sshd)\.(core|osgi)" groupId="$1.$2" artifactId="$2-$3"/>
   <mavenMappings namePattern="(org)\.(opentest4j)" groupId="$1.$2" artifactId="$2"/>
-  <mavenMappings namePattern="(org)\.(apiguardian)" groupId="$1.$2" artifactId="$2-api"/>
+  <mavenMappings namePattern="org.apache.batik.([^.]+)" groupId="org.apache.xmlgraphics" artifactId="batik-$1" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.w3c.css.sac" groupId="org.eclipse.birt.runtime" artifactId="org.w3c.css.sac"/>
-  <mavenMappings namePattern="org.apache.batik.css" groupId="org.apache.xmlgraphics" artifactId="batik-css" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="com.google.gson" groupId="com.google.code.gson" artifactId="gson"/>
-  <mavenMappings namePattern="com.sun.jna.platform" groupId="net.java.dev.jna" artifactId="jna-platform"/>
-  <mavenMappings namePattern="com.sun.jna" groupId="net.java.dev.jna" artifactId="jna"/>
-  <mavenMappings namePattern="org.w3c.dom.events" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.events"/>
-  <mavenMappings namePattern="org.w3c.dom.smil" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.smil"/>
-  <mavenMappings namePattern="org.w3c.dom.svg" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.svg"/>
+  <mavenMappings namePattern="(org\.bouncycastle)\.([^.]+)" groupId="$1" artifactId="$2-jdk18on" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
+  <mavenMappings namePattern="(com\.sun\.el|org.apache.jasper.glassfish)" groupId="org.eclipse.jetty.orbit" artifactId="$1"/>
+  <mavenMappings namePattern=".*" groupId="\$maven-groupId\$" artifactId="\$maven-artifactId\$" versionPattern=".*" versionTemplate="\$maven-version\$"/>
+  <mavenDependencyMapping iuNamePattern="(?!.*(org\.eclipse\.)).*|org\.eclipse\.emf.*|org\.eclipse\.ecf.*|org\.eclipse\.jetty.*" namespacePattern=".*" namePattern=".*" groupId="!" artifactId="!"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern="(.*)"/>
 </aggregator:Aggregation>

--- a/publish-to-maven-central/SDK4Mvn.aggran
+++ b/publish-to-maven-central/SDK4Mvn.aggran
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<analyzer:Analysis
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:analyzer="https://www.eclipse.org/cbi/p2repo/2021/aggregator/analyzer"
+    exclusion="org.eclipse.test.performance.*|eclipse-junit-tests|tooling.*|.*\.feature\.group|.*\.feature\.jar|.*.\.tests?(.source)?|.*\.tests\..*|org.eclipse.equinox.executable.*|org.eclipse.*.unittest.junit(.source)?|org.eclipse.platform.ide.executable.*|org.eclipse.platform.sdk.executable.*|org.eclipse.unittest.ui|org.eclipse.rcp\..*|org.eclipse.platform.ide|org.eclipse.platform.sdk|org.eclipse.sdk.ide.*|.*_root|(?!.*(org\.eclipse\.)).*|org.eclipse.emf.*|org.eclipse.jetty.*|org.eclipse.ecf.*"
+    aggregation="SDK4Mvn.aggr#/">
+  <contribution
+      contribution="SDK4Mvn.aggr#//@validationSets[label='main']/@contributions[label='sdk']"/>
+  <contribution
+      contribution="SDK4Mvn.aggr#//@validationSets[label='main']/@contributions[label='sdk_http']"/>
+</analyzer:Analysis>


### PR DESCRIPTION
dependencies when generating pom

Reduce the number of MavenMappings.

Use the new CBI aggregators features described here to map based Maven
metadata in p2 and to build Maven dependencies from java.package
requirements:

https://github.com/eclipse-cbi/p2repo-aggregator/issues/11

Disable the validation repositories because they're not needed given the
platform repository itself contains all requirements, and keeping them
also results analysis anomalies because Orbit IUs are resolved where
direct-from-Maven IUs are actually in the repository.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/67