### PR TITLE
Remove explicit mappings for some Maven artifacts

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -52,10 +52,6 @@
   <mavenMappings namePattern="org\.apache\.lucene\.core" groupId="org.apache.lucene" artifactId="lucene-core"/>
   <mavenMappings namePattern="org\.apache\.lucene\.analysis" groupId="org.apache.lucene" artifactId="lucene-analyzers"/>
   <mavenMappings namePattern="org\.apache\.ant$" groupId="org.apache.ant" artifactId="ant"/>
-  <mavenMappings namePattern="(org.apache)\.(sshd)\.(core)" groupId="$1.$2" artifactId="$2-$3"/>
-  <mavenMappings namePattern="(org\.objectweb)\.([^.]+)$" groupId="org.ow2.asm" artifactId="$2"/>
-  <mavenMappings namePattern="(org\.objectweb)\.([^.]+)\.([^.]+)" groupId="org.ow2.asm" artifactId="$2-$3"/>
-  <mavenMappings namePattern="org.tukaani.xz" groupId="org.tukaani" artifactId="xz" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.hamcrest.core" groupId="org.hamcrest" artifactId="hamcrest-core"/>
   <mavenMappings namePattern="(org\.junit)\.([^.]+)\.([^.]+)" groupId="$1.$2" artifactId="junit-$2-$3"/>
   <mavenMappings namePattern="(org\.junit)\.([^.]+)\.([^.]+)\.([^.]+)" groupId="$1.$2" artifactId="junit-$2-$3-$4"/>
@@ -64,9 +60,6 @@
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.w3c.css.sac" groupId="org.eclipse.birt.runtime" artifactId="org.w3c.css.sac"/>
   <mavenMappings namePattern="org.apache.batik.css" groupId="org.apache.xmlgraphics" artifactId="batik-css" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="com.google.gson" groupId="com.google.code.gson" artifactId="gson"/>
-  <mavenMappings namePattern="com.sun.jna.platform" groupId="net.java.dev.jna" artifactId="jna-platform"/>
-  <mavenMappings namePattern="com.sun.jna" groupId="net.java.dev.jna" artifactId="jna"/>
   <mavenMappings namePattern="org.w3c.dom.events" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.events"/>
   <mavenMappings namePattern="org.w3c.dom.smil" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.smil"/>
   <mavenMappings namePattern="org.w3c.dom.svg" groupId="org.eclipse.orbit.bundles" artifactId="org.w3c.dom.svg"/>


### PR DESCRIPTION
as GAV can be reliably inferred from p2 metadata.