### PR TITLE
Remove uneeded / from html links.

### DIFF
--- a/bundles/org.eclipse.test.performance/src/org/eclipse/test/performance/BasicResultsTable.java
+++ b/bundles/org.eclipse.test.performance/src/org/eclipse/test/performance/BasicResultsTable.java
@@ -228,7 +228,7 @@ public class BasicResultsTable implements IApplication{
         htmlString = htmlString + EOL;
 
         for (String component : usedComponents) {
-            htmlString = htmlString + "<a href=\"./basicPerformance.php/" +
+            htmlString = htmlString + "<a href=\"./basicPerformance.php" +
                 "?name=" + component +
                 "&build=" + CURRENT_BUILD +
                 "&baseline=" + BASELINE_BUILD +


### PR DESCRIPTION
It broke the links when I was testing  https://download.eclipse.org/eclipse/downloads/drops4/I20220728-1800/performance/performance.php 