### PR TITLE
Remove CVS content from rcp readme.

### DIFF
--- a/features/org.eclipse.rcp/rootfiles/readme/readme_eclipse.html
+++ b/features/org.eclipse.rcp/rootfiles/readme/readme_eclipse.html
@@ -619,87 +619,11 @@ after the release.
       name="mozTocId518357"> When the orientation of characters under the left and right edges of the block selection rectangle are not the same, the actual selection ranges (in memory) differ
       from the visual representation of the selection. (bug </a><a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=277929">277929</a>)
   </p>
-  <h3 id="I-Platform-Team-CVS">
+  <h3 id="I-Platform-Team">
     <a
       class="mozTocH3"
-      name="mozTocId263012">Platform - Team - CVS</a>
+      name="mozTocId263012">Platform - Team</a>
   </h3>
-  <p>
-    <a
-      class="mozTocH3"
-      name="mozTocId263012"> The following are known problems with the CVS repository provider only, and do not apply to other repository providers. Additional information on how to use CVS from
-      Eclipse can be found in the </a><a href="https://wiki.eclipse.org/CVS_FAQ">Eclipse CVS FAQ</a>.
-  </p>
-  <h4>
-    <a
-      class="mozTocH4"
-      name="mozTocId262771">CVS server compatibility</a>
-  </h4>
-  <p>
-    <a
-      class="mozTocH4"
-      name="mozTocId262771">The CVS plug-in parses messages returned from the CVS server. If the format of these messages is not as expected, some of the plug-in's functionality may be missing.
-      The CVS plug-in is compatible with all stable 1.11.X builds of the CVS server, and should be compatible with future releases in that stream unless text message formats change (the last tested
-      server was 1.11.22). As for the 1.12.X feature releases of CVS, the Eclipse CVS client has been tested with builds up to 1.12.13. However, future releases could easily break the Eclipse CVS
-      client. Basic functionality, such as Checkout, Commit, and Update, should always work, but there may be problems with more advanced commands such as Synchronizing and Browsing the repository.</a>
-  </p>
-  <h4>
-    <a
-      class="mozTocH4"
-      name="mozTocId532855">Connection cannot be found after initially missing</a>
-  </h4>
-  <p>
-    <a
-      class="mozTocH4"
-      name="mozTocId532855"> If a connection initially fails due to a network problem, the connection may continue to fail even when the network problem is fixed. In order to establish the
-      connection you must exit and restart Eclipse. (bug </a><a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=9295">9295</a>)
-  </p>
-  <h4>
-    <a
-      class="mozTocH4"
-      name="mozTocId660590">Received broken pipe signal" error from server</a>
-  </h4>
-  <p>
-    <a
-      class="mozTocH4"
-      name="mozTocId660590"> Eclipse sometimes performs multiple commands within a single connection to the server. This may cause problems with CVS servers that are running server scripts in
-      response to certain commands. (bugs </a><a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=23575">23575</a> and <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=23581">23581</a>)
-  </p>
-  <h4>
-    <a
-      class="mozTocH4"
-      name="mozTocId971246">Terminated with fatal signal 10" error from server</a>
-  </h4>
-  <p>
-    <a
-      class="mozTocH4"
-      name="mozTocId971246"> There is a bug in the CVS server related to some compression levels. If you get this error, changing the compression level on the CVS preference page may help. (bug </a><a
-      href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=15724">15724</a>)
-  </p>
-  <h4>
-    <a
-      class="mozTocH4"
-      name="mozTocId689776">error using ext connection method</a>
-  </h4>
-  <p>
-    <a
-      class="mozTocH4"
-      name="mozTocId689776"> There are a few situations that can result in an "Unknown response" error messages when using the ext connection method. One situation involves using an external
-      communications client (e.g. rsh or ssh) that adds CRs to the communications channel (bug </a><a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=21180">21180</a>). Another involves Eclipse not
-    properly reading the stderr output of the external communications tool. (bug <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=11633">11633</a>)
-  </p>
-  <h4>
-    <a
-      class="mozTocH4"
-      name="mozTocId50418">A disabled CVS capability may not be auto-enabled in existing workspaces</a>
-  </h4>
-  <p>
-    <a
-      class="mozTocH4"
-      name="mozTocId50418"> New in 3.0 is the ability to disable capabilities and the CVS support in Eclipse can be disabled. However, for backwards compatibility the CVS capability is
-      auto-enabled in existing workspaces that already contain CVS projects. The auto-enabling function may not run if the team support plugin is not loaded at startup. (bug </a><a
-      href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=66977">66977</a>)
-  </p>
   <h4>
     <a
       class="mozTocH4"


### PR DESCRIPTION
CVS support is no longer shipped thus this info in readme is pointless.