### PR TITLE
Improve the enrichment logic to ensure accuracy and correctness

### DIFF
--- a/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/ArtifactInfo.java
+++ b/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/ArtifactInfo.java
@@ -13,54 +13,80 @@
  ********************************************************************************/
 package org.eclipse.platform.releng.maven.pom;
 
-public class ArtifactInfo {
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-	private static final String SCM_GITROOT = "scm:git:https://git.eclipse.org/r/";
-	private static final String SCM_CGIT = "https://git.eclipse.org/c/";
+public class ArtifactInfo {
 
 	private static final String SCM_TAG_START = ";tag=\""; // git tag inside Eclipse-SourceReference
 
 	private static final String INDENT = "  ";
-	
-	private static final String FRONT_MATTER =
-			"  <licenses>\n" + 
-			"    <license>\n" + 
-			"      <name>Eclipse Public License - v 2.0</name>\n" + 
-			"      <url>https://www.eclipse.org/legal/epl-2.0/</url>\n" + 
-			"      <distribution>repo</distribution>\n" + 
-			"    </license>\n" + 
-			"  </licenses>\n" + 
-			"  <organization>\n" + 
-			"    <name>Eclipse Foundation</name>\n" + 
-			"    <url>http://www.eclipse.org/</url>\n" + 
-			"  </organization>\n" + 
-			"  <issueManagement>\n" + 
-			"    <system>Bugzilla</system>\n" + 
-			"    <url>https://bugs.eclipse.org/</url>\n" + 
-			"  </issueManagement>\n";
-	
-	public static final String COPYRIGHT =
-			"<!--\n" +
-			"  Copyright (c) 2016, 2018 GK Software SE and others.\n" +
-			"\n" + 
-			"  This program and the accompanying materials\n" + 
-			"  are made available under the terms of the Eclipse Public License 2.0\n" + 
-			"  which accompanies this distribution, and is available at\n" + 
-			"  https://www.eclipse.org/legal/epl-2.0/\n" + 
-			"\n" + 
-			"  SPDX-License-Identifier: EPL-2.0\n" + 
-			"\n" + 
-			"  Contributors:\n" + 
-			"      Stephan Herrmann - initial implementation\n" + 
-			"-->\n";
+
+	private static final Map<String, String> MOVED_SCMS = new HashMap<>();
+
+	private static final Pattern GITHUB_PATTERN = Pattern.compile("https://github.com/([^/]+)/.*");
+
+	static {
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/platform/eclipse.platform.releng",
+				"https://github.com/eclipse-platform/eclipse.platform.releng");
+		MOVED_SCMS.put("https://git.eclipse.org/r/platform/eclipse.platform.releng",
+				"https://github.com/eclipse-platform/eclipse.platform.releng");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/platform/eclipse.platform.ui",
+				"https://github.com/eclipse-platform/eclipse.platform.ui");
+		MOVED_SCMS.put("https://git.eclipse.org/r/platform/eclipse.platform.ui",
+				"https://github.com/eclipse-platform/eclipse.platform.ui");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/platform/eclipse.platform.text",
+				"https://github.com/eclipse-platform/eclipse.platform.text");
+		MOVED_SCMS.put("https://git.eclipse.org/r/platform/eclipse.platform.text",
+				"https://github.com/eclipse-platform/eclipse.platform.text");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/platform/eclipse.platform.debug",
+				"https://github.com/eclipse-platform/eclipse.platform.debug");
+		MOVED_SCMS.put("http://git.eclipse.org/gitroot/e4/org.eclipse.e4.tools",
+				"https://github.com/eclipse-platform/eclipse.platform.ui.tools");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/platform/eclipse.platform.ua",
+				"https://github.com/eclipse-platform/eclipse.platform.ua");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/platform/eclipse.platform.swt",
+				"https://github.com/eclipse-platform/eclipse.platform.swt");
+
+		MOVED_SCMS.put("https://gihub.com/eclipse-platform/eclipse.platform.ua",
+				"https://github.com/eclipse-platform/eclipse.platform.ua");
+		MOVED_SCMS.put("https://github.com/eclipse-platform/org.eclipse.ui.tools",
+				"https://github.com/eclipse-platform/eclipse.platform.ui.tools");
+
+		MOVED_SCMS.put("https://git.eclipse.org/r/equinox/rt.equinox.bundles", "https://github.com/eclipse-equinox/p2");
+		MOVED_SCMS.put("https://git.eclipse.org/r/equinox/rt.equinox.p2", "https://github.com/eclipse-equinox/p2");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/equinox/rt.equinox.p2", "https://github.com/eclipse-equinox/p2");
+		MOVED_SCMS.put("https://git.eclipse.org/r/equinox/rt.equinox.framework",
+				"https://github.com/eclipse-equinox/equinox");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/equinox/rt.equinox.bundles",
+				"https://github.com/eclipse-equinox/equinox");
+
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/jdt/eclipse.jdt.core.binaries",
+				"https://github.com/eclipse-jdt/eclipse.jdt.core.binaries");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/jdt/eclipse.jdt.ui",
+				"https://github.com/eclipse-jdt/eclipse.jdt.ui");
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/jdt/eclipse.jdt.core",
+				"https://github.com/eclipse-jdt/eclipse.jdt.core");
+		MOVED_SCMS.put("https://git.eclipse.org/r/jdt/eclipse.jdt.core",
+				"https://github.com/eclipse-jdt/eclipse.jdt.core");
+
+		MOVED_SCMS.put("git://git.eclipse.org/gitroot/pde/eclipse.pde.ui",
+				"https://github.com/eclipse-pde/eclipse.pde");
+		MOVED_SCMS.put("https://git.eclipse.org/r/pde/eclipse.pde.ui", "https://github.com/eclipse-pde/eclipse.pde");
+	}
 
 	public String bsn;
-	public String name;
 	public String scmConnection;
-	
+
 	@Override
 	public String toString() {
-		return "ArtifactInfo [bsn=" + bsn + ", name=" + name + ", scmConnection=" + scmConnection + "]";
+		return "ArtifactInfo [bsn=" + bsn + ", scmConnection=" + scmConnection + "]";
 	}
 
 	public String toPomFragment() {
@@ -68,98 +94,102 @@ public class ArtifactInfo {
 			fixData();
 			StringBuilder buf = new StringBuilder();
 			String indent = INDENT;
-			element("url", indent, buf, "http://www.eclipse.org/"+getProject());
-			buf.append(FRONT_MATTER);
+			element("url", indent, buf,  getProjectURL());
 			if (this.scmConnection == null) {
-				System.err.println("No scm info for "+this.bsn);
+				System.err.println("No scm info for " + this.bsn);
 			} else {
 				String connectionUrl = extractScmConnection();
 				String url = extractScmUrl(connectionUrl);
-				element("scm", indent, buf,
-					subElement("connection", connectionUrl),
-					subElement("tag", extractScmTag()),
-					subElement("url", url));
-				Developer.addUrlDevelopers(url, this.bsn, indent, buf);
-//				String projRepo = extractProjectRepo(url);
-//				if (projRepo != null) {
-//					Developer.addDevelopers(projRepo, this.bsn, indent, buf);
-//				} else {
-//					System.err.println("Could not determine git repo for "+this.bsn+" from "+url);
-//				}
+				buf.append(getFrontMatter(url));
+				element("scm", indent, buf, subElement("connection", connectionUrl), subElement("tag", extractScmTag()),
+						subElement("url", url));
+				Developer.addUrlDevelopers(getProjectURL(), indent, buf);
 			}
 			return buf.toString();
 		} catch (RuntimeException e) {
-			System.err.println("Failed for "+this);
+			System.err.println("Failed for " + this);
 			throw e;
 		}
 	}
-	
+
+	private static String getFrontMatter(String scmURL) {
+		String FRONT_MATTER = "" + //
+				"  <licenses>\n" + //
+				"    <license>\n" + //
+				"      <name>Eclipse Public License - v 2.0</name>\n" + //
+				"      <url>https://www.eclipse.org/legal/epl-2.0/</url>\n" + //
+				"      <distribution>repo</distribution>\n" + //
+				"    </license>\n" + //
+				"  </licenses>\n" + //
+				"  <organization>\n" + //
+				"    <name>Eclipse Foundation</name>\n" + //
+				"    <url>https://www.eclipse.org/</url>\n" + //
+				"  </organization>\n" + //
+				"  <issueManagement>\n" + //
+				"    <system>Github</system>\n" + //
+				"    <url>" + scmURL + "/issues</url>\n" + //
+				"  </issueManagement>\n"; //
+		return FRONT_MATTER;
+	}
+
 	private void fixData() {
 		if (this.scmConnection == null) {
 			if (this.bsn.equals("org.eclipse.jdt.core.compiler.batch")) {
 				// not a regular OSGi bundle, scm info missing:
 				this.scmConnection = "scm:git:https://github.com/eclipse-jdt/eclipse.jdt.core.git;path=\"org.eclipse.jdt.core\"";
-				System.out.println("Fixed scmUrl for "+this.bsn);
-			} else if (this.bsn.startsWith("org.eclipse.emf")) {
-				this.scmConnection = "scm:git:https://git.eclipse.org/r/emf/org.eclipse.emf";
-				System.out.println("Fixed scmUrl for "+this.bsn);
-			} else if (this.bsn.startsWith("org.eclipse.ecf")) {
-				this.scmConnection = "scm:git:https://git.eclipse.org/r/ecf/org.eclipse.ecf;tag=\"R-Release_HEAD-sdk_feature-279_279\"";
-				System.out.println("Fixed scmUrl for "+this.bsn);
+				System.out.println("Fixed scmUrl for " + this.bsn);
 			}
-		}
-		if (this.name == null || this.name.charAt(0) == '%') {
-			if (this.bsn.equals("org.eclipse.core.resources.win32.x86")
-					|| this.bsn.equals("org.eclipse.core.resources.win32.x86_64")) {
-				this.name = "Core Resource Management Win32 Fragment";
-				System.out.println("Fixed name for "+this.bsn);
-			}
+		} else {
+			this.scmConnection = "scm:git:" + extractScmUrl(extractScmConnection()) + ".git";
 		}
 	}
 
-	String getProject() {
-		if (this.bsn.startsWith("org.eclipse.jdt"))
-			return "jdt";
-		if (this.bsn.startsWith("org.eclipse.pde"))
-			return "pde";
-		if (this.bsn.startsWith("org.eclipse.ecf"))
-			return "ecf";
-		return "platform";
+	String getProjectURL() {
+		String scmURL = extractScmUrl(extractScmConnection());
+		Matcher matcher = GITHUB_PATTERN.matcher(scmURL);
+		if (matcher.matches()) {
+			String organization = matcher.group(1);
+			return "https://projects.eclipse.org/projects/" + organization.replace('-', '.');
+		}
+
+		return "https://projects.eclipse.org/projects/";
 	}
-	
+
 	String extractScmConnection() {
 		int semi = this.scmConnection.indexOf(';');
 		if (semi == -1)
 			return this.scmConnection;
 		return this.scmConnection.substring(0, semi);
 	}
-	
+
 	String extractScmTag() {
 		int tagStart = this.scmConnection.indexOf(SCM_TAG_START);
 		if (tagStart == -1)
 			return null;
-		int next = this.scmConnection.indexOf("\"", tagStart+SCM_TAG_START.length());
+		int next = this.scmConnection.indexOf("\"", tagStart + SCM_TAG_START.length());
 		if (next == -1)
 			next = this.scmConnection.length();
-		return this.scmConnection.substring(tagStart+SCM_TAG_START.length(), next);
+		return this.scmConnection.substring(tagStart + SCM_TAG_START.length(), next);
 	}
+
+	private static final Set<String> visitedSCMs = new HashSet<>();
 
 	String extractScmUrl(String connection) {
-		if (connection.startsWith(SCM_GITROOT))
-			return SCM_CGIT+connection.substring(SCM_GITROOT.length());
-		return connection.replace("eclipse.org/r", "eclipse.org/c");
+		String scmURL = connection.replaceAll("^scm:git:", "").replaceAll("^scm:githttps:", "https:")
+				.replaceAll("\\.git$", "");
+		String movedSCMURL = MOVED_SCMS.get(scmURL);
+		if (movedSCMURL != null) {
+			scmURL = movedSCMURL;
+		}
+		if (EnrichPoms.test && visitedSCMs.add(scmURL)) {
+			try (InputStream in = new URL(scmURL).openStream()) {
+			} catch (Exception ex) {
+				ex.printStackTrace();
+			}
+		}
+		return scmURL;
 	}
 
-	String extractProjectRepo(String url) {
-		int pos = 0;
-		for (int i=0; i<5; i++) {
-			pos = url.indexOf('/', pos+1);
-			if (pos == -1)
-				return null;
-		}
-		return url.substring(0, pos);
-	}
-	
 	public static void element(String tag, String indent, StringBuilder buf, String... contents) {
 		buf.append(indent).append('<').append(tag).append('>');
 		if (contents.length == 1 && !contents[0].contains("\n")) {
@@ -168,7 +198,7 @@ public class ArtifactInfo {
 			buf.append("\n");
 			for (String content : contents)
 				if (content != null)
-					for (String line: content.split("\\n")) 
+					for (String line : content.split("\\n"))
 						buf.append(indent).append(INDENT).append(line).append('\n');
 			buf.append(indent);
 		}

--- a/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/Developer.java
+++ b/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/Developer.java
@@ -16,130 +16,20 @@ package org.eclipse.platform.releng.maven.pom;
 import static org.eclipse.platform.releng.maven.pom.ArtifactInfo.element;
 import static org.eclipse.platform.releng.maven.pom.ArtifactInfo.subElement;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-public abstract class Developer {
+public class Developer {
 
-	static final String PLATFORM_GIT_REPO = "https://git.eclipse.org/c/platform";
+	private final String url;
 
-	static final String[] ROLE_LEAD = { "Project Lead" };
-	
-	public static final HashMap<String, List<Developer>> developersPerRepo = new HashMap<>();
-	public static final Set<String> projects = new HashSet<>();
-	static {
-		// currently unused:
-		Developer dani = new IndividualDeveloper("Dani Megert");
-		developersPerRepo.put(PLATFORM_GIT_REPO,
-				Arrays.asList(dani));
-		developersPerRepo.put("https://git.eclipse.org/c/equinox",
-				Arrays.asList(new IndividualDeveloper("Ian Bull"), new IndividualDeveloper("Pascal Rapicault"), new IndividualDeveloper("Thomas Watson")));
-		developersPerRepo.put("https://git.eclipse.org/c/jdt",
-				Arrays.asList(dani));
-		developersPerRepo.put("https://git.eclipse.org/c/pde",
-				Arrays.asList(new IndividualDeveloper("Curtis Windatt"), new IndividualDeveloper("Vikas Chandra")));
-		//
-
-		projects.add("eclipse.platform");
-		projects.add("eclipse.jdt");
-		projects.add("eclipse.pde");
-		projects.add("rt.equinox");
+	public Developer(String url) {
+		this.url = url;
 	}
 
-	public static void addIndividualDevelopers(String projRepo, String bsn, String indent, StringBuilder buf) {
-		List<Developer> devs = getDevelopers(projRepo, bsn);
-		if (devs == null)
-			System.err.println("No developers for project repo "+projRepo+" ("+bsn+")");
-		else
-			element("developers", indent, buf, Developer.pomSubElements(devs));
-		
-	}
-
-	public static void addUrlDevelopers(String gitUrl, String bsn, String indent, StringBuilder buf) {
-		String whoSInvolved = gitRepoToWhoSInvolved(gitUrl);
-		if (whoSInvolved == null)
-			System.err.println("No developers for project repo "+gitUrl+" ("+bsn+")");
-		else
-			element("developers", indent, buf, Developer.pomSubElements(Collections.singletonList(new UrlDeveloper(whoSInvolved))));
-	}
-
-	private static String gitRepoToWhoSInvolved(String gitUrl) {
-		if ((gitUrl == null) || (gitUrl.trim() == "")) {
-			return "https://projects.eclipse.org/projects/eclipse.platform/who";
-		}
-		String[] tokens = gitUrl.split("/");
-		String project = "eclipse.platform";
-		if (tokens.length >=5) {
-			switch (tokens[3]) {
-				case "eclipse-jdt" : 
-					project = "eclipse.jdt";
-					break;
-				case "eclipse-pde" : 
-					project = "eclipse.pde";
-					break;
-				case "eclipse-equinox" : 
-					project = "eclipse.equinox";
-					break;
-				case "eclipse-platform" : 
-					project = "eclipse.platform";
-					break;
-				default : 
-					project = "eclipse.platform";
-					break;
-			}
-		}
-		return "https://projects.eclipse.org/projects/"+project+"/who";
-		
-		/*
-		if (tokens.length >= 6) {
-			String token = tokens[5]; // https://git.eclipse.org/c/equinox/rt.equinox.framework.git => start with rt.equinox.framework
-			int end = token.endsWith(".git") ? token.length()-".git".length() : token.length();
-			String project = token.substring(0, end);
-			// Special case for e4 projects
-			if ((project.contains("org.eclipse.ui"))||((project.contains("org.eclipse.e4")))) {
-				project  = "eclipse.platform";
-			} else {
-				while (!projects.contains(project)) {
-					end = project.lastIndexOf('.');
-					if (end == -1)
-						return null;
-					project = project.substring(0, end); // cut off non-matching tail segment
-				}
-			}
-			return "https://projects.eclipse.org/projects/"+project+"/who";
-		} else if (tokens.length >= 5) {
-			String token = tokens[4]; // https://github.com/eclipse-platform/eclipse.platform.releng.git => start with eclipse.platform.releng
-			int end = token.endsWith(".git") ? token.length()-".git".length() : token.length();
-			String project = token.substring(0, end);
-			// Special case for e4 projects
-			if ((project.contains("org.eclipse.ui"))||((project.contains("org.eclipse.e4")))) {
-				project  = "eclipse.platform";
-			} else {
-				while (!projects.contains(project)) {
-					end = project.lastIndexOf('.');
-					if (end == -1)
-						return null;
-					project = project.substring(0, end); // cut off non-matching tail segment
-				}
-			}
-			return "https://projects.eclipse.org/projects/"+project+"/who";
-		}
-		return null;
-		*/
-	}
-
-	private static List<Developer> getDevelopers(String projRepo, String bsn) {
-		// "platform" artifacts in pde repos:
-		if ("org.eclipse.ui.views.log".equals(bsn) || "org.eclipse.ui.trace".equals(bsn))
-			return developersPerRepo.get(PLATFORM_GIT_REPO);
-		// "platform" artifacts in jdt repos:
-		if ("org.eclipse.ltk.core.refactoring".equals(bsn) || "org.eclipse.ltk.ui.refactoring".equals(bsn))
-			return developersPerRepo.get(PLATFORM_GIT_REPO);
-		return developersPerRepo.get(projRepo);
+	public static void addUrlDevelopers(String projectURL, String indent, StringBuilder buf) {
+		element("developers", indent, buf,
+				Developer.pomSubElements(Collections.singletonList(new Developer(projectURL + "/who"))));
 	}
 
 	private static String pomSubElements(List<Developer> devs) {
@@ -148,51 +38,8 @@ public abstract class Developer {
 			developer.toPom(buf, "");
 		return buf.toString();
 	}
-	
-	protected abstract void toPom(StringBuilder buf, String string);
 
-	/** Represent project leads as individual developers. */
-	static class IndividualDeveloper extends Developer {
-		String name;
-		String[] roles;
-		public IndividualDeveloper(String name) {
-			this.name = name;
-			this.roles = ROLE_LEAD;
-		}
-		
-		protected void toPom(StringBuilder buf, String indent) {
-			element("developer", indent, buf,
-					subElement("name", this.name),
-					getRolesElement());
-		}
-
-		String getRolesElement() {
-			StringBuilder rolesElement = new StringBuilder();
-			element("roles", "", rolesElement, String.join("\n", getRoleElements()));
-			return rolesElement.toString();
-		}
-
-		String[] getRoleElements() {
-			String[] roleElements = new String[this.roles.length];
-			for (int i = 0; i < this.roles.length; i++) {
-				StringBuilder subBuf = new StringBuilder();
-				element("role", "", subBuf, this.roles[i]);
-				roleElements[i] = subBuf.toString();
-			}
-			return roleElements;
-		}
-	}
-
-	/** Represent developers using the "Who's Involved" web page. */
-	static class UrlDeveloper extends Developer {
-		String url;
-		public UrlDeveloper(String url) {
-			this.url = url;
-		}
-		
-		protected void toPom(StringBuilder buf, String indent) {
-			element("developer", indent, buf,
-					subElement("url", this.url));
-		}
+	protected void toPom(StringBuilder buf, String indent) {
+		element("developer", indent, buf, subElement("url", this.url));
 	}
 }

--- a/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/EnrichPoms.java
+++ b/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/EnrichPoms.java
@@ -18,24 +18,67 @@ import java.io.OutputStreamWriter;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
+/**
+ * To test locally, the /publish-to-maven-central/SDK4Mvn.aggr must be used to
+ * produce the Mavenized p2 repository. To do that, you need to install the "CBI
+ * Aggregator Editor" from <a href=
+ * "https://download.eclipse.org/cbi/updates/p2-aggregator/tools/nightly/latest">https://download.eclipse.org/cbi/updates/p2-aggregator/tools/nightly/latest</a>.
+ * Then you can open the SDK4Mvn.aggr in the Aggregator Editor and invoke
+ * <em>Build Aggregation</em> from the context menu. That generates results in
+ * <code>${user.home}/build</code>. Only the contents of following three folders are
+ * actually published to Maven (perhaps equinox in the future), so you can run
+ * <code>main</code> for just those folders:
+ * 
+ * <pre>
+ * ~/build/final/org/eclipse/pde
+ * ~/build/final/org/eclipse/jdt
+ * ~/build/final/org/eclipse/platform
+ * -test
+ * -verbose
+ * </pre>
+ * 
+ * The <code>-test</code> will test that the SCM URL actually exists. The
+ * <code>-verbose</code> will print the contents to each enriched pom to
+ * <code>System.out</code>.
+ */
 public class EnrichPoms {
 
 	private static final String DOT_POM = ".pom";
 	private static final String DOT_JAR = ".jar";
 	private static final String BAK_SUFFIX = "-bak";
 
+	static boolean test;
+
+	static boolean verbose;
 
 	public static void main(String[] args) throws IOException {
-		Path path = FileSystems.getDefault().getPath(args[0]);
-		if (!Files.exists(path) || !Files.isDirectory(path))
-			throw new IllegalArgumentException(path.toString()+ " is not a directory");
-		
-		Files.walk(path)
-			.filter(EnrichPoms::isArtifact)
-			.forEach(EnrichPoms::enrich);
+		Set<Path> paths = new LinkedHashSet<>();
+		for (String arg : args) {
+			if ("-test".equals(arg)) {
+				test = true;
+			} else if ("-verbose".equals(arg)) {
+				verbose = true;
+			} else {
+				Path path = FileSystems.getDefault().getPath(arg);
+				if (!Files.exists(path) || !Files.isDirectory(path))
+					throw new IllegalArgumentException(path.toString() + " is not a directory");
+				paths.add(path);
+			}
+		}
+
+		if (paths.isEmpty()) {
+			throw new IllegalArgumentException("No directories specified");
+		}
+
+		for (Path path : paths) {
+			Files.walk(path).filter(EnrichPoms::isArtifact).forEach(EnrichPoms::enrich);
+		}
 	}
-	
+
 	public static boolean isArtifact(Path path) {
 		if (Files.isDirectory(path))
 			return false;
@@ -47,32 +90,26 @@ public class EnrichPoms {
 
 	public static Path getCorrespondingJarPath(Path pomPath) {
 		String fileName = pomPath.getFileName().toString();
-		String jarName = fileName.substring(0, fileName.length()-DOT_POM.length())+DOT_JAR; 
+		String jarName = fileName.substring(0, fileName.length() - DOT_POM.length()) + DOT_JAR;
 		return pomPath.resolveSibling(jarName);
 	}
 
 	public static void enrich(Path pomPath) {
 		try {
-			Path backPath = pomPath.resolveSibling(pomPath.getFileName().toString()+BAK_SUFFIX);
-			if (Files.exists(backPath)) {
-				System.out.println("Skipping (-bak exists): "+pomPath);
-				return;
-			}
 			Path jarPath = getCorrespondingJarPath(pomPath);
 			ArtifactInfo info = ManifestReader.read(jarPath);
+			if (info == null) {
+				// Don't process features because they aren't published.
+				return;
+			}
+
+			Path backPath = pomPath.resolveSibling(pomPath.getFileName().toString() + BAK_SUFFIX);
 			Path newPom = Files.createTempFile(pomPath.getParent(), "", DOT_POM);
 			try (OutputStreamWriter out = new OutputStreamWriter(Files.newOutputStream(newPom))) {
-				boolean copyrightInserted = false;
 				boolean detailsInserted = false;
-				for (String line : Files.readAllLines(pomPath)) {
+				for (String line : Files.readAllLines(Files.exists(backPath) ? backPath : pomPath)) {
 					out.write(line);
 					out.append('\n');
-					if (!copyrightInserted) {
-						if (line.equals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")) {
-							out.append(ArtifactInfo.COPYRIGHT);
-							copyrightInserted = true;
-						}
-					}
 					if (!detailsInserted) {
 						if (line.contains("</description>")) {
 							out.append(info.toPomFragment());
@@ -81,11 +118,16 @@ public class EnrichPoms {
 					}
 				}
 			}
+			if (verbose) {
+				String pomText = Files.readString(newPom);
+				System.out.println(pomText);
+			}
 			if (!Files.exists(backPath))
 				Files.move(pomPath, backPath);
-			Files.move(newPom, pomPath);
+			Files.move(newPom, pomPath, StandardCopyOption.REPLACE_EXISTING);
 		} catch (IOException e) {
-			System.err.println("Failed to rewrite pom "+pomPath+": "+e.getClass()+": "+e.getMessage());
+			System.err.println("Failed to rewrite pom " + pomPath + ": " + e.getClass() + ": " + e.getMessage());
+			e.printStackTrace();
 		}
 	}
 }

--- a/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/ManifestReader.java
+++ b/publish-to-maven-central/src/org/eclipse/platform/releng/maven/pom/ManifestReader.java
@@ -18,42 +18,36 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map.Entry;
-import java.util.Properties;
 import java.util.jar.Attributes;
-import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class ManifestReader {
 
+	private static final String FEATURE_XML = "feature.xml";
 	private static final String MANIFEST_MF = "META-INF/MANIFEST.MF";
 	// Eclipse headers in MANIFEST.MF:
 	private static final String BUNDLE_SYMBOLIC_NAME 		= "Bundle-SymbolicName";
-	private static final String BUNDLE_NAME 				= "Bundle-Name";
-	private static final String BUNDLE_LOCALIZATION 		= "Bundle-Localization";
 	private static final String ECLIPSE_SOURCE_REFERENCES 	= "Eclipse-SourceReferences";
-	private static final String FRAGMENT_HOST 				= "Fragment-Host";
 	
-	private static final String DOT_PROPERTIES 				= ".properties";
-	private static final String BUNDLE_PROPERTIES 			= "OSGI-INF/l10n/bundle.properties";
-
 	public static ArtifactInfo read(Path path) throws FileNotFoundException, IOException {
 		File file = path.toFile();
 		try (ZipFile zip = new ZipFile(file)) {
+			ZipEntry featureEntry = zip.getEntry(FEATURE_XML);
+			if (featureEntry != null) {
+				return null;
+			}
+			
 			ZipEntry entry = zip.getEntry(MANIFEST_MF);
 			Manifest mf = new Manifest(zip.getInputStream(entry));
 			Attributes mainAttributes = mf.getMainAttributes();
 //			printAllMainAttributes(mainAttributes);
 
-			String localization = mainAttributes.getValue(BUNDLE_LOCALIZATION);
-			boolean isFragment = mainAttributes.getValue(FRAGMENT_HOST) != null;
-			Properties translations = getTranslations(file, localization, isFragment);
 
 			ArtifactInfo info = new ArtifactInfo();
 			info.bsn = getSymbolicName(mainAttributes);
 			info.scmConnection = mainAttributes.getValue(ECLIPSE_SOURCE_REFERENCES);
-			info.name = getBundleName(mainAttributes, translations, isFragment);
 			return info;
 		}
 	}
@@ -64,51 +58,6 @@ public class ManifestReader {
 		if (semi != -1)
 			return bsn.substring(0, semi); // cut off ;singleton etc...
 		return bsn;
-	}
-
-	static Properties getTranslations(File jarFile, String propFile, boolean isFragment) throws IOException {
-		try (JarFile jf = new JarFile(jarFile)) {
-			ZipEntry zipEntry = getTranslationsEntry(jf, propFile);
-			if (zipEntry == null) {
-				if (!isFragment) { // expected for fragments :-/
-					if (propFile != null)
-						System.err.println("translations "+propFile+DOT_PROPERTIES+" missing for "+jarFile.getName());
-					else
-						System.err.println("translations "+BUNDLE_PROPERTIES+" missing for "+jarFile.getName());
-				}
-				return null;
-			}
-			Properties properties = new Properties();
-			properties.load(jf.getInputStream(zipEntry));
-			return properties;
-		}
-	}
-	
-	static ZipEntry getTranslationsEntry(JarFile jf, String propFile) {
-		ZipEntry entry = null;
-		if (propFile != null)
-			entry = jf.getEntry(propFile+DOT_PROPERTIES);
-		if (entry == null)
-			entry = jf.getEntry(BUNDLE_PROPERTIES);
-		return entry;
-	}
-
-	static String getBundleName(Attributes mainAttributes, Properties translations, boolean isFragment) {
-		String name = mainAttributes.getValue(BUNDLE_NAME);
-		if (name.charAt(0) == '%') {
-			if (translations == null) {
-				if (isFragment) { // TODO
-					System.err.println("Cannot translate fragment name "+name+" for "+getSymbolicName(mainAttributes));
-				} else {
-					System.err.println("Cannot translate bundle name "+name+" for "+getSymbolicName(mainAttributes));
-				}
-				return name;
-			}
-			String translated = translations.getProperty(name.substring(1));
-			if (translated != null)
-				return translated;
-		}
-		return name;
 	}
 
 	// debugging


### PR DESCRIPTION
Make it easier to test this locally and document how to do that. Support processing multiple folders so that one can more easily test just the folders that will actually be published to Maven. Gracefully ignore features for easier local testing.

Simplify things that are no longer used/needed. A pom really doen't need a copyright XML comment.  Given the name and description are already in the POM, we don't need to read so much detail (translaations) in the ManifestReader.

Test that the scm URLs are correct. Remap older git.eclipse.org URLs to the new URLs.  Use github issue links not bugzilla links.

Use project.eclipse.org links because the www.eclipse.org pages very out-of-date.  Use that also for the developer link.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/113