### PR TITLE
Add support for Windows on Arm64 (WoA)

### DIFF
--- a/features/org.eclipse.platform-feature/feature.xml
+++ b/features/org.eclipse.platform-feature/feature.xml
@@ -114,6 +114,16 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.core.net.win32.aarch64"
+         os="win32"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.core.net.win32.x86_64"
          os="win32"
          arch="x86_64"
@@ -382,9 +392,29 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.core.resources.win32.aarch64"
+         os="win32"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.core.resources.win32.x86_64"
          os="win32"
          arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.core.filesystem.win32.aarch64"
+         os="win32"
+         arch="aarch64"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -454,6 +484,25 @@
          download-size="0"
          install-size="0"
          version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.security.win32"
+         os="win32"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.security.win32.aarch64"
+         os="win32"
+         arch="aarch64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
          unpack="false"/>
 
    <plugin


### PR DESCRIPTION
to include the new fragments for WoA in the current 'org.eclipse.platform-feature' feature.