### PR TITLE
Remove SLF4J Plugin from o.e.help feature

### DIFF
--- a/features/org.eclipse.help-feature/feature.xml
+++ b/features/org.eclipse.help-feature/feature.xml
@@ -190,13 +190,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.core.net"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
If a Feature includes a Plugin, it usually includes it with a specific name and the version that was in the TP when the feature was build. This prevents consumers from using a slf4j bundle with different symbolic-name or different version in their TP or product.

This is part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588