### PR TITLE
Remove org.apache.commons.logging from o.e.help feature

### DIFF
--- a/features/org.eclipse.help-feature/feature.xml
+++ b/features/org.eclipse.help-feature/feature.xml
@@ -50,13 +50,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.logging"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.jasper.glassfish"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
If a Feature includes a Plugin, it usually includes it with a specific name and the version that was in the TP when the feature was build. This prevents consumers from using for example a slf4j-bridge that provides binary compatible packages and classes but redirects all logging to slf4j in their TP or product.


Although not directly related to the move to slf4j from Maven-Central or slf4j-2, this is similar like https://github.com/eclipse-platform/eclipse.platform.releng/pull/118.