### PR TITLE
Exploit improved version ranges for package requirement dependencies

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -2,20 +2,20 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease">
   <validationSets label="main">
     <contributions label="sdk">
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/">
+      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.26-I-builds/">
         <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.feature.group"/>
         <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.source.feature.group"/>
       </repositories>
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/">
+      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.26-I-builds/">
         <bundles name="org.eclipse.jdt.core.compiler.batch"/>
       </repositories>
     </contributions>
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/">
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/">
         <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.feature.group"/>
         <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.source.feature.group"/>
       </repositories>
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/">
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/">
         <bundles name="org.eclipse.jdt.core.compiler.batch"/>
       </repositories>
     </contributions>
@@ -48,12 +48,11 @@
   <mavenMappings namePattern="org.apache.batik.([^.]+)" groupId="org.apache.xmlgraphics" artifactId="batik-$1" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.w3c.css.sac" groupId="org.eclipse.birt.runtime" artifactId="org.w3c.css.sac"/>
-  <mavenMappings namePattern="(org\.bouncycastle)\.([^.]+)" groupId="$1" artifactId="$2-jdk18on" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="(com\.sun\.el|org.apache.jasper.glassfish)" groupId="org.eclipse.jetty.orbit" artifactId="$1"/>
   <mavenMappings namePattern=".*" groupId="\$maven-groupId\$" artifactId="\$maven-artifactId\$" versionPattern=".*" versionTemplate="\$maven-version\$"/>
   <mavenDependencyMapping iuNamePattern="(?!.*(org\.eclipse\.)).*|org\.eclipse\.emf.*|org\.eclipse\.ecf.*|org\.eclipse\.jetty.*" namespacePattern=".*" namePattern=".*" groupId="!" artifactId="!"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern="(.*)"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
Use 4.26-I-builds in the SDK4Mvn.aggr.

Eliminate the mapping for bouncycastle.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/119