### PR TITLE
Remove easymock.psf

### DIFF
--- a/bundles/org.eclipse.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.test; singleton:=true
-Bundle-Version: 3.5.100.qualifier
+Bundle-Version: 3.5.200.qualifier
 Eclipse-BundleShape: dir
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.test/easymock.psf
+++ b/bundles/org.eclipse.test/easymock.psf
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<psf version="2.0">
-<provider id="org.eclipse.team.cvs.core.cvsnature">
-<project reference="1.0,:extssh:dev.eclipse.org:/cvsroot/tools,org.eclipse.orbit/org.easymock,org.easymock,v2_4"/>
-</provider>
-</psf>

--- a/bundles/org.eclipse.test/pom.xml
+++ b/bundles/org.eclipse.test/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.test</groupId>
   <artifactId>org.eclipse.test</artifactId>
-  <version>3.5.100-SNAPSHOT</version>
+  <version>3.5.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars> 


### PR DESCRIPTION
It's no longer used and even if it was this psf file pointing to cvs can do no good.