### PR TITLE
Factorize lucene mappings, expand apache commons mapping

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -37,10 +37,8 @@
   <mavenMappings namePattern="(com\.jcraft)\.(.*)" groupId="$1" artifactId="$2"/>
   <mavenMappings namePattern="javax\.annotation" groupId="jakarta.annotation" artifactId="jakarta.annotation-api"/>
   <mavenMappings namePattern="(javax.inject)" groupId="$1" artifactId="$1" versionPattern="([^.]+)\.0(?:\..*)?" versionTemplate="$1"/>
-  <mavenMappings namePattern="org\.apache\.(commons)\.([^.-]+)" groupId="$1-$2" artifactId="$1-$2" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
-  <mavenMappings namePattern="org\.apache\.lucene\.core" groupId="org.apache.lucene" artifactId="lucene-core"/>
-  <mavenMappings namePattern="org.apache.lucene.analyzers-common" groupId="org.apache.lucene" artifactId="lucene-analyzers-common"/>
-  <mavenMappings namePattern="org.apache.lucene.analyzers-smartcn" groupId="org.apache.lucene" artifactId="lucene-analyzers-smartcn"/>
+  <mavenMappings namePattern="org\.apache\.commons\.(jxpath|logging)" groupId="commons-$1" artifactId="commons-$1" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
+  <mavenMappings namePattern="org\.apache\.lucene\.(.*)" groupId="org.apache.lucene" artifactId="lucene-$1"/>
   <mavenMappings namePattern="org\.apache\.ant$" groupId="org.apache.ant" artifactId="ant"/>
   <mavenMappings namePattern="org.apache.batik.([^.]+)" groupId="org.apache.xmlgraphics" artifactId="batik-$1" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>
   <mavenMappings namePattern="org.junit" groupId="junit" artifactId="junit" versionPattern="([^.]+)\.([^.]+)\.0(?:\..*)?" versionTemplate="$1.$2"/>


### PR DESCRIPTION
Some apache commons lib already come from Maven and have necessary metadata so the "natural" mapping should be used. Explicit which libs (coming from Orbit) require a custom mapping.