### PR TITLE
Map osgi.bundle requirement onto a dependency on the resolved version

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -49,5 +49,6 @@
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
+  <mavenDependencyMapping namespacePattern="osgi\.bundle" namePattern="(?!.*(org\.eclipse\.(emf|ecf))).*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
Exclude EMF and ECF requirements because these don't provide snapshot versions and we want to be able to publish snapshot builds.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/128