### PR TITLE
Include -qualifier in the version of SDK4Mvn.aggr's dependency mappings

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -46,9 +46,9 @@
   <mavenMappings namePattern="(com\.sun\.el|org.apache.jasper.glassfish)" groupId="org.eclipse.jetty.orbit" artifactId="$1"/>
   <mavenMappings namePattern=".*" groupId="\$maven-groupId\$" artifactId="\$maven-artifactId\$" versionPattern=".*" versionTemplate="\$maven-version\$"/>
   <mavenDependencyMapping iuNamePattern="(?!.*(org\.eclipse\.)).*|org\.eclipse\.emf.*|org\.eclipse\.ecf.*|org\.eclipse\.jetty.*" namespacePattern=".*" namePattern=".*" groupId="!" artifactId="!"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
-  <mavenDependencyMapping namespacePattern="osgi\.bundle" namePattern="(?!.*(org\.eclipse\.(emf|ecf))).*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
-  <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
+  <mavenDependencyMapping namespacePattern="osgi\.bundle" namePattern="(?!.*(org\.eclipse\.(emf|ecf))).*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
+  <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
The -qualifier is replaced with -SNAPSHOT if the Maven Mapping of the resolved bundle has isSnapshot is true and by the empty string otherwise.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/136