### PR TITLE
Special handling needed for org.w3c.css.sac in SDK4Mvn.aggr

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -49,6 +49,7 @@
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.(apt|tool))" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
+  <mavenDependencyMapping namespacePattern="osgi\.bundle|java\.package" namePattern="org\.w3c\.css\.sac" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="1.3.1.v200903091627"/>
   <mavenDependencyMapping namespacePattern="osgi\.bundle" namePattern="(?!.*(org\.eclipse\.(emf|ecf))).*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
This is a bundle that comes from Orbit and is only available in the BIRT runtime with an odd version, i.e., 1.3.1.v200903091627

https://repo1.maven.org/maven2/org/eclipse/birt/runtime/org.w3c.css.sac/1.3.1.v200903091627/

https://github.com/eclipse-platform/eclipse.platform.releng/issues/136