### PR TITLE
Improve SDK4Mvn.aggr to better handle glassfish

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -50,6 +50,7 @@
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt).internal.(compiler\.apt)\..*" groupId="$1" artifactId="$1.$2" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern="(org.eclipse.jdt)(.internal|.core)?.compiler.*" groupId="$1" artifactId="$1.core" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="osgi\.bundle|java\.package" namePattern="org\.w3c\.css\.sac" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro.qualifier"/>
-  <mavenDependencyMapping namespacePattern="osgi\.bundle" namePattern="(?!.*(org\.eclipse\.(emf|ecf))).*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
+  <mavenDependencyMapping namespacePattern="osgi\.bundle|java\.package" namePattern="org\.apache\.jasper\..*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro.v201112011158"/>
+  <mavenDependencyMapping namespacePattern="osgi\.bundle|org\.eclipse\.equinox\.p2\.iu" namePattern="(?!.*(org\.eclipse\.(emf|ecf))).*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
   <mavenDependencyMapping namespacePattern="java\.package" namePattern=".*" groupId="*" artifactId="*" versionRangePattern=".*" versionRangeTemplate="major.minor.micro-qualifier"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng/issues/53

The latest version used from Orbit, 2.2.2.v201501141630, is newer than the one latest available from Jetty:

https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/org.apache.jasper.glassfish/2.2.2.v201112011158/