### PR TITLE
Various clean ups and code improvements in org.eclipse.test

### DIFF
--- a/bundles/org.eclipse.test/src/org/eclipse/test/ClassLoaderTools.java
+++ b/bundles/org.eclipse.test/src/org/eclipse/test/ClassLoaderTools.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat Inc. and others.
+ * Copyright (c) 2018, 2022 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Vector;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.internal.framework.EquinoxBundle;
@@ -162,23 +161,14 @@ class ClassLoaderTools {
 
 		@Override
 		protected Enumeration<URL> findResources(String name) throws IOException {
-			Enumeration<URL> enumFinal = null;
-			for (int i = 0; i < bundleList.size(); i++) {
-				if (i == 0) {
-					enumFinal = bundleList.get(i).getResources(name);
-					continue;
+			List<URL> resources = new ArrayList<>();
+			for (Bundle bundle : bundleList) {
+				Enumeration<URL> bundleResources = bundle.getResources(name);
+				while (bundleResources != null && bundleResources.hasMoreElements()) {
+					resources.add(bundleResources.nextElement());
 				}
-				Enumeration<URL> e2 = bundleList.get(i).getResources(name);
-				Vector<URL> temp = new Vector<>();
-				while (enumFinal != null && enumFinal.hasMoreElements()) {
-					temp.add(enumFinal.nextElement());
-				}
-				while (e2 != null && e2.hasMoreElements()) {
-					temp.add(e2.nextElement());
-				}
-				enumFinal = temp.elements();
 			}
-			return enumFinal;
+			return Collections.enumeration(resources);
 		}
 	}
 }

--- a/bundles/org.eclipse.test/src/org/eclipse/test/ClassLoaderTools.java
+++ b/bundles/org.eclipse.test/src/org/eclipse/test/ClassLoaderTools.java
@@ -28,34 +28,31 @@ import org.osgi.framework.Bundle;
 
 @SuppressWarnings("restriction")
 class ClassLoaderTools {
-	public static ClassLoader getPluginClassLoader(String getfTestPluginName, ClassLoader currentTCCL) {
-		Bundle bundle = Platform.getBundle(getfTestPluginName);
-		if (bundle == null) {
-			throw new IllegalArgumentException("Bundle \"" + getfTestPluginName //$NON-NLS-1$
-					+ "\" not found. Possible causes include missing dependencies, too restrictive version ranges, or a non-matching required execution environment."); //$NON-NLS-1$
-		}
+
+	static ClassLoader getPluginClassLoader(Bundle bundle, ClassLoader currentTCCL) {
 		return new TestBundleClassLoader(bundle, currentTCCL);
 	}
 
-	public static String getClassPlugin(String className) {
-		int index = className.lastIndexOf('.');
-		String plugin = null;
-		while (index != -1) {
-			plugin = className.substring(0, index);
-			if (Platform.getBundle(plugin) != null) {
-				break;
+	static Bundle getTestBundle(String pluginName, String className) {
+		if (pluginName != null) {
+			Bundle bundle = Platform.getBundle(pluginName);
+			if (bundle != null) {
+				return bundle;
 			}
-			index = className.lastIndexOf('.', index - 1);
+		} else if (className != null) {
+			for (int index = className.lastIndexOf('.'); index != -1; index = className.lastIndexOf('.', index - 1)) {
+				String symbolicName = className.substring(0, index);
+				Bundle bundle = Platform.getBundle(symbolicName);
+				if (bundle != null) {
+					return bundle;
+				}
+			}
 		}
-		return plugin;
+		throw new IllegalArgumentException("Bundle \"" + pluginName
+				+ "\" not found. Possible causes include missing dependencies, too restrictive version ranges, or a non-matching required execution environment."); //$NON-NLS-1$
 	}
 
-	public static ClassLoader getJUnit5Classloader(List<String> platformEngine) {
-		List<Bundle> platformEngineBundles = new ArrayList<>();
-		for (String string : platformEngine) {
-			Bundle bundle = Platform.getBundle(string);
-			platformEngineBundles.add(bundle);
-		}
+	static ClassLoader getJUnit5Classloader(List<Bundle> platformEngineBundles) {
 		return new MultiBundleClassLoader(platformEngineBundles);
 	}
 


### PR DESCRIPTION
This PR consists of commit improve `org.eclipse.test`:
1. Format code using the standard Eclipse-Formatter and apply basic JDT clean ups.
2. Improve and clean up the code structure.

@akurtakov is there a good way to test that this does not cause a regression or do we just have to await I-build results?
I can also split this further into smaller pieces to simplify review and they can be submitted one by one and an I-build could be awaited between each.
