### PR TITLE
add missing source bundles for R4_26 release

### DIFF
--- a/publish-to-maven-central/sourceBundles.txt
+++ b/publish-to-maven-central/sourceBundles.txt
@@ -1,0 +1,10 @@
+
+eclipse-platform/eclipse.platform.ui.tools.git \
+	bundles/org.eclipse.e4.tools.emf.ui \
+	R4_26 \
+	org/eclipse/platform org.eclipse.e4.tools.emf.ui 4.7.400
+
+eclipse-platform/eclipse.platform.ui.git \
+  bundles/org.eclipse.e4.ui.progress \
+  R4_26 \ 
+  org/eclipse/platform org.eclipse.e4.ui.progress 0.3.600 


### PR DESCRIPTION
Maven staging is failing with 
"failureMessage	Missing: no sources jar found in folder '/org/eclipse/platform/org.eclipse.e4.tools.emf.ui/4.7.400'
failureMessage	Missing: no sources jar found in folder '/org/eclipse/platform/org.eclipse.e4.ui.progress/0.3.600'"

so adding sources.