### PR TITLE
Stop producing a next baseline and remove special handling for ecj

### DIFF
--- a/publish-to-maven-central/CBIaggregator.sh
+++ b/publish-to-maven-central/CBIaggregator.sh
@@ -33,23 +33,6 @@ function require_executable() {
 	fi
 }
 
-function create_baseline() {
-	cd ${Repo}
-	for line in `find org/eclipse -name \*[0-9].jar | sort`
-	do
-		file=`basename $line`
-		name=`echo $file | sed -e 's/\(.*\)-.*/\1/' | tr '.' '_'`
-		version=`echo $file | sed -e 's/.*-\(.*\)\.jar/\1/'`
-		previous=`eval echo \\${VERSION_$name}`
-		if [ "$previous" != "" ]
-		then
-			version=${previous},${version}
-		fi
-		echo VERSION_$name=$version
-	done > ${WORKSPACE}/baseline-next.txt 
-	cd -
-}	
-
 #================================================================================
 #   (1) Install and run the CBI aggregator
 #================================================================================
@@ -385,13 +368,6 @@ do
     buildSourceJar $line 
 done < ${WORKSPACE}/work/sourceBundles.txt
 
-# copy ecj-src from build output (NB: we are mapping from SDK version (4.x) back to ECJ version (3.x)):
-scp genie.releng@projects-storage.eclipse.org:${DROPS4}/${SDK_BUILD_DIR}/ecjsrc-${SDK_VERSION}.jar org/eclipse/jdt/ecj/${ECJ_VERSION}/ecj-${ECJ_VERSION}-sources.jar
-
 echo "========== Repo completed ========="
-
-create_baseline
-
-echo "========== Next baseline created ========="
 
 cd ${WORKSPACE}

--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -1,28 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease">
+<aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease">
   <validationSets label="main">
     <contributions label="sdk">
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.27-I-build">
-        <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.feature.group"/>
-        <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.source.feature.group"/>
-      </repositories>
-      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.27-I-build">
-        <bundles name="org.eclipse.jdt.core.compiler.batch"/>
-      </repositories>
+      <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.27-I-build"/>
     </contributions>
     <contributions label="sdk_http">
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.27-I-builds">
-        <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.feature.group"/>
-        <mapRules xsi:type="aggregator:ExclusionRule" name="org.eclipse.e4.core.tools.feature.source.feature.group"/>
-      </repositories>
-      <repositories location="https://download.eclipse.org/eclipse/updates/4.27-I-builds">
-        <bundles name="org.eclipse.jdt.core.compiler.batch"/>
-      </repositories>
+      <repositories location="https://download.eclipse.org/eclipse/updates/4.27-I-builds"/>
     </contributions>
-    <validationRepositories enabled="false" location="/home/data/httpd/download.eclipse.org/modeling/emf/emf/builds/release/2.32/"/>
-    <validationRepositories enabled="false" location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.32/"/>
-    <validationRepositories enabled="false" location="/home/data/httpd/download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>
-    <validationRepositories enabled="false" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20221123021534/repository/"/>
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="ppc64le"/>

--- a/publish-to-maven-central/properties.sh
+++ b/publish-to-maven-central/properties.sh
@@ -18,11 +18,7 @@ SDK_BUILD_DIR=R-4.26-202211231800
 SDK_VERSION=4.26
 FILE_ECLIPSE=${DROPS4}/${SDK_BUILD_DIR}/eclipse-SDK-${SDK_VERSION}-linux-gtk-x86_64.tar.gz
 
-# JDT / ECJ:
-ECJ_VERSION=3.32.0
-
 # AGGREGATOR:
-# URL_AGG_UPDATES=https://download.eclipse.org/cbi/updates/aggregator/headless/4.13/I20200825-1209/
 URL_AGG_UPDATES=https://download.eclipse.org/cbi/updates/p2-aggregator/products/nightly/latest
 
 # LOCAL TOOLS:

--- a/publish-to-maven-central/publishProject.sh
+++ b/publish-to-maven-central/publishProject.sh
@@ -108,6 +108,8 @@ do
 			-Durl=${URL} -DrepositoryId=${REPO} \
 			-Dfile=${sourcesFile} -DpomFile=${pomFile} -Dclassifier=sources \
 			>> .log/sources-upload.txt
+	else
+		echo -e "\tMissing ${sourcesFile}"
 	fi
 
 	if [ -f "${javadocFile}" ]; then
@@ -117,7 +119,9 @@ do
 			-Durl=${URL} -DrepositoryId=${REPO} \
 			-Dfile=${javadocFile} -DpomFile=${pomFile} -Dclassifier=javadoc \
 			>> .log/javadoc-upload.txt
-		fi
+	else
+		echo -e "\tMissing ${javadocFile}"
+	fi
 done
 
 ls -la .log

--- a/publish-to-maven-central/sourceBundles.txt
+++ b/publish-to-maven-central/sourceBundles.txt
@@ -1,11 +1,1 @@
 
-eclipse-platform/eclipse.platform.ui.tools.git \
-  bundles/org.eclipse.e4.tools.emf.ui \
-  R4_26 \
-  org/eclipse/platform org.eclipse.e4.tools.emf.ui 4.7.400
-
-eclipse-platform/eclipse.platform.ui.git \
-  bundles/org.eclipse.e4.ui.progress \
-  R4_26 \ 
-  org/eclipse/platform org.eclipse.e4.ui.progress 0.3.600 
-


### PR DESCRIPTION
Echo messages for missing source/javadoc.
Simplify the SDK4Mvn.aggr to just aggregate everything which eliminates the missing source bundles specified in sourceBundles.txt.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/126