### PR TITLE
Add a test for missing -sources.jar to ensure that missing is OK

### DIFF
--- a/publish-to-maven-central/publishProject.sh
+++ b/publish-to-maven-central/publishProject.sh
@@ -109,7 +109,12 @@ do
 			-Dfile=${sourcesFile} -DpomFile=${pomFile} -Dclassifier=sources \
 			>> .log/sources-upload.txt
 	else
-		echo -e "\tMissing ${sourcesFile}"
+		# If the -sources.jar is missing, and the main jar contains .class files, then we won't be able to promote this to Maven central.
+		if unzip -l ${file} | grep -q -e '.class$'; then 
+			echo "BUILD FAILURE ${file} contains .class files and requires a ${sourcesFile}" | tee >> .log/sources-upload.txt
+		else
+			echo -e "\tMissing ${sourcesFile} but ${file} contains no .class files."
+		fi; 
 	fi
 
 	if [ -f "${javadocFile}" ]; then


### PR DESCRIPTION
For some artifacts, the -sources jar is not present in Maven central:

https://repo1.maven.org/maven2/org/eclipse/platform/org.eclipse.swt/3.122.0/

I believe that's okay only in the case when the jar does not contain .class files so we should fail the build only in the case when the -sources.jar is missing *and* the jar contains .class files.

https://github.com/eclipse-platform/eclipse.platform.releng/issues/126