### PR TITLE
Convert 3rd party deps to import

### DIFF
--- a/features/org.eclipse.test-feature/feature.xml
+++ b/features/org.eclipse.test-feature/feature.xml
@@ -19,6 +19,17 @@
       %license
    </license>
 
+   <requires>
+      <import plugin="org.mockito.mockito-core"/>
+      <import plugin="net.bytebuddy.byte-buddy" />
+      <import plugin="net.bytebuddy.byte-buddy-agent" />
+      <import plugin="org.objenesis" />
+      <import plugin="junit-jupiter-api" />
+      <import plugin="assertj-core" />
+      <import plugin="org.junit" />
+      <import plugin="org.hamcrest.core" />
+   </requires>
+
    <plugin
          id="org.eclipse.ant.optional.junit"
          download-size="0"
@@ -55,64 +66,9 @@
          unpack="false"/>
 
    <plugin
-         id="org.junit"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.hamcrest.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.objenesis"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.mockito.mockito-core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="net.bytebuddy.byte-buddy"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="net.bytebuddy.byte-buddy-agent"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.core.tests.harness"
          download-size="0"
          install-size="0"
          version="0.0.0"/>
-
-   <plugin
-         id="junit-jupiter-api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="assertj-core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
 
 </feature>


### PR DESCRIPTION
Instead of including so the feature doesn't have to be touched every time dependency changes.
Only reason to not do that for now is having sources included but this feature doesn't have sources at all so not an issue.