### PR TITLE
Update target platform's bytebuddy dependencies to the latest available

### DIFF
--- a/features/org.eclipse.test-feature/forceQualifierUpdate.txt
+++ b/features/org.eclipse.test-feature/forceQualifierUpdate.txt
@@ -19,3 +19,4 @@ JUnit 5.9.1 update
 Touch to pick latest deps https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/628
 Touch to pick latest deps https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/791 +again
 Update junit dependencies: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/799
+Update bytebuddy dependencies: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/807


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/807