### PR TITLE
Include JDT Bytecode Outline view in the SDK feature

### DIFF
--- a/features/org.eclipse.sdk/feature.xml
+++ b/features/org.eclipse.sdk/feature.xml
@@ -53,6 +53,7 @@
          
    <includes id="org.eclipse.jdt.astview.feature" version="0.0.0"/>
    <includes id="org.eclipse.jdt.jeview.feature" version="0.0.0"/>
+   <includes id="org.eclipse.jdt.bcoview.feature" version="0.0.0"/>
 
    <requires>
       <import feature="org.eclipse.emf.common.source" version="2.7.0" match="compatible"/>


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/364