### PR TITLE
Update SDK4Mvn.aggr to use includeSouces

### DIFF
--- a/publish-to-maven-central/SDK4Mvn.aggr
+++ b/publish-to-maven-central/SDK4Mvn.aggr
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease">
+<aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="SDK4Mvn" packedStrategy="UNPACK_AS_SIBLING" type="R" mavenResult="true" versionFormat="MavenRelease" includeSources="true">
   <validationSets label="main">
     <contributions label="sdk">
       <repositories enabled="false" location="/home/data/httpd/download.eclipse.org/eclipse/updates/4.27-I-build"/>


### PR DESCRIPTION
This ensures that Maven publishing will include and find corresponding source bundles regardless of whether each source bundle is included in a feature.

https://github.com/eclipse-cbi/p2repo-aggregator/issues/13