### PR TITLE
Revert "Remove bytebuddy includes for easier TP updates"

### DIFF
--- a/features/org.eclipse.test-feature/feature.xml
+++ b/features/org.eclipse.test-feature/feature.xml
@@ -82,6 +82,20 @@
          unpack="false"/>
 
    <plugin
+         id="net.bytebuddy.byte-buddy"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="net.bytebuddy.byte-buddy-agent"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.core.tests.harness"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng#194

It broke tests https://download.eclipse.org/eclipse/downloads/drops4/I20230207-1800/testresults/ep427I-unit-mac64-java17_macosx.cocoa.x86_64_17/directorLogs/director-org.eclipse.equinox.p2.tests.ui.log :
```
Software being installed: Equinox Provisioning Tests (Incubation) 1.3.500.v20221015-0807 (org.eclipse.equinox.p2.tests.ui 1.3.500.v20221015-0807)
	Missing requirement: Equinox Provisioning Tests (Incubation) 1.8.1000.v20230129-0715 (org.eclipse.equinox.p2.tests 1.8.1000.v20230129-0715) requires 'osgi.bundle; net.bytebuddy.byte-buddy 0.0.0' but it could not be found
	Cannot satisfy dependency:
		From: Equinox Provisioning Tests (Incubation) 1.3.500.v20221015-0807 (org.eclipse.equinox.p2.tests.ui 1.3.500.v20221015-0807)
		To: osgi.bundle; org.eclipse.equinox.p2.tests 1.2.0
Installation failed.
```