### PR TITLE
Revert "Use org.glassfish.web.javax.servlet.jsp"

### DIFF
--- a/features/org.eclipse.help-feature/feature.xml
+++ b/features/org.eclipse.help-feature/feature.xml
@@ -50,7 +50,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.glassfish.web.javax.servlet.jsp"
+         id="org.apache.jasper.glassfish"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Reverts eclipse-platform/eclipse.platform.releng#175
Help system is broken with this jasper implementation.