### PR TITLE
TracingSuite: add lock information to stacktraces

### DIFF
--- a/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.test.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.test.performance; singleton:=true
-Bundle-Version: 3.19.100.qualifier
+Bundle-Version: 3.19.200.qualifier
 Bundle-Activator: org.eclipse.test.internal.performance.PerformanceTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.test.performance/pom.xml
+++ b/bundles/org.eclipse.test.performance/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.test</groupId>
   <artifactId>org.eclipse.test.performance</artifactId>
-  <version>3.19.100-SNAPSHOT</version>
+  <version>3.19.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
      <code.ignoredWarnings>-warn:-raw,unchecked</code.ignoredWarnings>

--- a/bundles/org.eclipse.test.performance/src/org/eclipse/test/TracingSuite.java
+++ b/bundles/org.eclipse.test.performance/src/org/eclipse/test/TracingSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -238,20 +238,9 @@ public class TracingSuite extends Suite {
             stream.format("freeMemory (after GC): %11d\n", Runtime.getRuntime().freeMemory());
 
             ThreadMXBean threadStuff = ManagementFactory.getThreadMXBean();
-            ThreadInfo[] allThreads = threadStuff.getThreadInfo(threadStuff.getAllThreadIds(), 200);
+            ThreadInfo[] allThreads = threadStuff.dumpAllThreads(true, true, 200);
             for (ThreadInfo threadInfo : allThreads) {
-                stream.print("\"");
-                stream.print(threadInfo.getThreadName());
-                stream.print("\": ");
-                stream.print(threadInfo.getThreadState());
-                stream.println();
-                final StackTraceElement[] elements = threadInfo.getStackTrace();
-                for (StackTraceElement element : elements) {
-                    stream.print("    ");
-                    stream.print(element);
-                    stream.println();
-                }
-                stream.println();
+                stream.print(threadInfo);
             }
             for (Thread t : Thread.getAllStackTraces().keySet()) {
                 String name = t.getName();


### PR DESCRIPTION
To get the reason of hanging thread.
see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/797